### PR TITLE
Fix improper error logging.

### DIFF
--- a/libs/iqrf/udp/judp-examples/src/main/java/com/microrisc/udp/examples/WriteRead.java
+++ b/libs/iqrf/udp/judp-examples/src/main/java/com/microrisc/udp/examples/WriteRead.java
@@ -99,7 +99,11 @@ public final class WriteRead {
                 try {
                     socket.receive(packet);
                 } catch ( SocketException e ) {
-                    System.err.println("Socket error: " + e);
+                    if(stopFlag) {
+                        System.out.println("Socket closed.");
+                    } else {
+                        System.err.println("Socket error: " + e);
+                    }
                     continue;
                 } catch ( UnknownHostException e ) {
                     System.err.println("Uknown host error: " + e);


### PR DESCRIPTION
This is a minor fix that prevents logging of `java.net.SocketException` when the example application ends. This exception is actually a false positive because the application closes the socket itself, therefore it is not an error.
